### PR TITLE
Cambiar "frontend" por "framework" en el link de la página inicial

### DIFF
--- a/harvester-app/src/main.js
+++ b/harvester-app/src/main.js
@@ -18,7 +18,7 @@ const createWindow = () => {
   });
 
   // Cargar el archivo HTML de inicio de sesión.
-  mainWindow.loadFile(path.join(__dirname, './frontend/vistas/FrameLayout.html'));
+  mainWindow.loadFile(path.join(__dirname, './framework/vistas/FrameLayout.html'));
 
   // Poner la ventana en modo de pantalla completa.
   mainWindow.maximize();


### PR DESCRIPTION
Se corrigió el link de la página inicial de la aplicación para que apunte al folder correcto tras la refactorización.